### PR TITLE
Version 1.0.5 - Progress Marker & Shutdown Resiliency

### DIFF
--- a/Source/sparklogs/Public/sparklogs.h
+++ b/Source/sparklogs/Public/sparklogs.h
@@ -72,6 +72,12 @@ SPARKLOGS_API FString ITLCalcUniqueFieldName(const TSharedPtr<FJsonObject> Objec
 /** Returns a sanitized version of the given string that is safe to use as an INI key name */
 SPARKLOGS_API FString ITLSanitizeINIKeyName(const FString & In);
 
+/** Tries really hard to delete the given file, or if that fails to rename it. Returns true on success or false otherwise. */
+SPARKLOGS_API bool ITLPurgeFile(const FString & Path);
+
+/** Do a simple log file rotation if the current file is greater than the given size. Returns true if rotated. */
+SPARKLOGS_API bool ITLLogFileSimpleRotateIfTooLarge(FOutputDeviceFile* OutputDevice, const FString & Path, int64 MinSizeToRotate);
+
 /** The type of data compression to use. */
 enum class SPARKLOGS_API ITLCompressionMode
 {

--- a/sparklogs.uplugin
+++ b/sparklogs.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "1.0.4",
+	"VersionName": "1.0.5",
 	"FriendlyName": "SparkLogs",
 	"Description": "Ship game engine logs and analytics to SparkLogs, a cost effective, petabyte-scale cloud logging service that's actually a joy to use. Can also be used to ship logs and analytics to any HTTP(S) endpoint that accepts JSON.",
 	"Category": "Analytics",


### PR DESCRIPTION
During engine shutdown the plugin attempts to flush all data. If all data is successfully flushed, it will attempt to delete the queued data and clear the progress marker. In rare circumstances, it appears that there can be third-party interference deleting the queued data (e.g., A/V scanner still attempting to scan the file). The plugin previously did not confirm that the queued data was purged before clearing the progress marker. This led to a condition where the progress marker was cleared but the queued data was not, and queued data could be resent when the game next starts, causing duplicate data to get ingested.

This issue did not appear when the plugin was running only in Linux backend game servers, so it appears to be related to more common third-party interference with file deletion (A/V) on windows.

The plugin now tries more thoroughly to purge the queued data file (deleting with several attempts and then moving the file aside if it can't delete), and then only clearing the progress marker if the queued data file is indeed confirmed as purged. This ensures that dup analytics data will not get sent.

The issue was reproduced by manually locking the queued data file in another process while the game exits. These updates are confirmed to resolve the duplicate data getting sent.

Other changes:
* Rotate the plugin ops log on startup if it's more than 5 MB (only affects servers).
* Log session ID in default message for session start/end.
* Only log value in default message if it's not null.
* Wait up to 15 seconds instead of 6 for final flush at end of game.