### PR TITLE
Version 1.0.8 - Clients send data more often

### DIFF
--- a/Config/FilterPlugin.ini
+++ b/Config/FilterPlugin.ini
@@ -7,3 +7,5 @@
 ;    /README.txt
 ;    /Extras/...
 ;    /Binaries/ThirdParty/*.dll
+/README.md
+/LICENSE

--- a/Source/sparklogs/Public/sparklogs.h
+++ b/Source/sparklogs/Public/sparklogs.h
@@ -130,7 +130,7 @@ public:
 	static constexpr double MinRetryIntervalSecs = 15.0;
 	// This should not be longer than 5 minutes, because the ingest dedup cache expires a few minutes later
 	static constexpr double MaxRetryIntervalSecs = 5 * 60;
-	static constexpr double WaitForFlushToCloudOnShutdown = 15.0;
+	static constexpr double WaitForFlushToCloudOnShutdown = 16.0;
 	static constexpr bool DefaultIncludeCommonMetadata = true;
 	static constexpr bool DefaultDebugLogRequests = false;
 	static constexpr bool DefaultAutoStart = true;
@@ -141,8 +141,8 @@ public:
 	static constexpr double MinEditorProcessingIntervalSecs = 0.5;
 	static constexpr double DefaultEditorProcessingIntervalSecs = 2.0;
 	// There could be millions of clients, so give more time for data to queue up before flushing...
-	static constexpr double MinClientProcessingIntervalSecs = 60.0 * 1;
-	static constexpr double DefaultClientProcessingIntervalSecs = 60.0 * 5;
+	static constexpr double MinClientProcessingIntervalSecs = 15.0;
+	static constexpr double DefaultClientProcessingIntervalSecs = 30.0;
 
 	static constexpr bool DefaultServerCollectAnalytics = true;
 	static constexpr bool DefaultServerCollectLogs = true;

--- a/sparklogs.uplugin
+++ b/sparklogs.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "1.0.7",
+	"VersionName": "1.0.8",
 	"FriendlyName": "SparkLogs",
 	"Description": "Ship game engine logs and analytics to SparkLogs, a cost effective, petabyte-scale cloud logging service that's actually a joy to use. Can also be used to ship logs and analytics to any HTTP(S) endpoint that accepts JSON.",
 	"Category": "Analytics",


### PR DESCRIPTION
* Client build configurations will send queued data after 30 seconds.
* Adjust timeouts during shutdown to have at least 1 retry happen.