### PR TITLE
Version 1.0.9: Dedup resiliency across restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # SparkLogs Unreal Engine Plugin
 
 This is an [open source](LICENSE) plugin for [Unreal Engine](https://unrealengine.com/) to efficiently send game engine analytics (client/server) and/or logs (server)
-data to any HTTPS endpoint that can receive JSON data, including the [SparkLogs Cloud](https://sparklogs.com/).
+data to any HTTPS endpoint that can receive JSON data, including the [SparkLogs Cloud](https://sparklogs.com/) or open source forwarding agents like [vector.dev](https://vector.dev/docs/reference/configuration/sources/http_server/).
 
-Join the [discord](https://discord.gg/Yu8F8w8tDw) to ask questions, provide feedback, or collaborate on enhancements.
+Join the [discord community](https://discord.gg/Yu8F8w8tDw) to ask questions, provide feedback, or collaborate on enhancements.
 
 [Free accounts](https://sparklogs.com/docs/getting-started/create-account#pricing) are available with SparkLogs to ingest up to 25 GB/month.
 That's enough free quota for over 1 million analytics sessions of data every month (assuming each session records 16 events and each event is about 1.5 KiB).
 
-The SparkLogs Cloud provides a turn-key solution that scales effortlessly with your game to 100s of millions of active users,
+The SparkLogs Cloud provides a [turn-key analytics pipeline](https://sparklogs.com/docs/game-engine-analytics) that scales effortlessly with your game to 100s of millions of active users,
 [auto extracts](https://sparklogs.com/docs/ingest/autoextract/overview) structured fields from your unstructured logs,
 and also provides daily analytics snapshots, user geolocation (country), currency conversion for analytics purchase events, and other features.
 SparkLogs has no cardinality limits and has no limits on the size and number of custom JSON fields for your logs and analytics events.
@@ -46,7 +46,9 @@ SparkLogs has no cardinality limits and has no limits on the size and number of 
   events, and then when the game engine is restarted, it will resend any queued data. It will also
   detect any previously open game engine analytics session that was not closed properly (e.g., due
   to a crash) and will automatically close that session with a session end time of the last known
-  analytics event for that session. Works with concurrent game engine sessions.
+  analytics event for that session. Works with concurrent game engine sessions. Payloads for retried
+  requests are identical, even across process crashes, allowing SparkLogs to deduplicate identical
+  payloads and avoid recording duplicate data.
 
 * **Security**: Data is transmitted over HTTPS and requests are authenticated.
 
@@ -63,7 +65,8 @@ SparkLogs has no cardinality limits and has no limits on the size and number of 
 
 ## Compatibility
 
-Tested to be compatible with Unreal Engine 4.27 through 5.6 for Windows, Mac, Linux, iOS, and Android.
+Tested to be compatible with Unreal Engine 4.27 through 5.6 for Windows, Mac, and Linux.
+iOS and Android are in a beta state where they are expected to work but are not yet as mature as desktop platforms.
 The plugin is likely compatible with slightly older and newer engine versions but such support is untested.
 
 Pull requests to add support for other platforms are welcome. The plugin currently
@@ -76,7 +79,14 @@ Refer to the [full plugin documentation](https://sparklogs.com/docs/ingest/data-
 for how to install, configure, use, and deploy the plugin. This also includes information on
 game engine analytics features, including session management and supported event types.
 
+## Automated Testing
+
+The plugin has a full suite of unit and automation tests. Run them by opening the session frontend
+in the Unreal Editor, going to the Automation tab, and then selecting and running the `sparklogs` tests.
+
 ## Contributing
 
 All contributions are welcome! Open an issue or pull request, and please join our
 [discord](https://discord.gg/Yu8F8w8tDw) to share your ideas and collaborate.
+Be sure to run the test suite before opening a pull request, and also include a note
+confirming that you're willing to contribute the code under the project's open source license.

--- a/Source/sparklogs/Private/Tests/sparklogsTest.cpp
+++ b/Source/sparklogs/Private/Tests/sparklogsTest.cpp
@@ -58,6 +58,10 @@ public:
         FString StateIni = ITLGetIndexedStateFileINI(InstanceIndex);
         if (StateIni != GGameUserSettingsIni)
         {
+            // We've got to purge the information from the UE INI cache as well or it will still be readable in future tests!!!
+            GConfig->EmptySection(ITL_CONFIG_SECTION_NAME, StateIni);
+            GConfig->Flush(false, StateIni);
+            GConfig->Remove(StateIni);
             IFileManager::Get().Delete(*StateIni, false, false, true);
         }
     }

--- a/Source/sparklogs/Private/sparklogs.cpp
+++ b/Source/sparklogs/Private/sparklogs.cpp
@@ -1327,7 +1327,7 @@ bool FsparklogsWriteHTTPPayloadProcessor::ProcessPayload(TArray<uint8>& JSONPayl
 					// Mark that we've successfully processed the request...
 					RequestSucceeded.AtomicSet(true);
 				}
-				else if (EHttpResponseCodes::TooManyRequests == ResponseCode || ResponseCode >= EHttpResponseCodes::ServerError)
+				else if (EHttpResponseCodes::TooManyRequests == ResponseCode || EHttpResponseCodes::RequestTimeout == ResponseCode || ResponseCode >= EHttpResponseCodes::ServerError)
 				{
 					UE_LOG(LogPluginSparkLogs, Warning, TEXT("HTTPPayloadProcessor::ProcessPayload: Retryable HTTP response: status=%d, msg=%s"), (int)ResponseCode, *ResponseBody.TrimStartAndEnd());
 					// Clear any session affinity cookies in case that is part of the issue...
@@ -1335,7 +1335,7 @@ bool FsparklogsWriteHTTPPayloadProcessor::ProcessPayload(TArray<uint8>& JSONPayl
 					RequestSucceeded.AtomicSet(false);
 					RetryableFailure.AtomicSet(true);
 				}
-				else if (EHttpResponseCodes::BadRequest == ResponseCode)
+				else if (EHttpResponseCodes::BadRequest == ResponseCode || EHttpResponseCodes::RequestTooLarge == ResponseCode)
 				{
 					// Something about this input was unable to be processed -- drop this input and pretend success so we can continue, but warn about it
 					UE_LOG(LogPluginSparkLogs, Warning, TEXT("HTTPPayloadProcessor::ProcessPayload: HTTP response indicates input cannot be processed. Will skip this payload! status=%d, msg=%s"), (int)ResponseCode, *ResponseBody.TrimStartAndEnd());

--- a/Source/sparklogs/Private/sparklogs.cpp
+++ b/Source/sparklogs/Private/sparklogs.cpp
@@ -942,7 +942,7 @@ void FsparklogsSettings::MarkLastWrittenAnalyticsEvent()
 	if (KnownLastEvent != ITLEmptyDateTime)
 	{
 		FTimespan Interval = Now - KnownLastEvent;
-		if (FMath::Abs(Interval.GetTotalSeconds()) < 15.0)
+		if (FMath::Abs(Interval.GetTotalSeconds()) < 5.0)
 		{
 			// Only update this timestamp every few seconds for efficiency
 			return;
@@ -1716,6 +1716,7 @@ bool FsparklogsReadAndStreamToCloud::AccrueWrittenBytes(int N)
 bool FsparklogsReadAndStreamToCloud::RequestFlush()
 {
 	// Clear any pending retry timer so we retry immediately
+	WorkerLastFlushFailed.AtomicSet(false);
 	FlushClearMinNextPlatformTime.Increment();
 	// If we've already requested a stop, a flush is impossible
 	if (StopRequestCounter.GetValue() > 0)
@@ -1744,8 +1745,8 @@ bool FsparklogsReadAndStreamToCloud::FlushAndWait(int N, bool ClearRetryTimer, b
 	{
 		ITL_DBG_UE_LOG(LogPluginSparkLogs, Display, TEXT("STREAMER|FlushAndWait|Clearing retry timer..."));
 		// Clear any pending retry timer so we retry immediately
-		FlushClearMinNextPlatformTime.Increment();
 		WorkerLastFlushFailed.AtomicSet(false);
+		FlushClearMinNextPlatformTime.Increment();
 	}
 
 	for (int i = 0; i < N; i++)

--- a/Source/sparklogs/Private/sparklogs.cpp
+++ b/Source/sparklogs/Private/sparklogs.cpp
@@ -208,6 +208,24 @@ bool ITLIsMobilePlatform()
 #endif
 }
 
+bool ITLIsConsolePlatform()
+{
+#if PLATFORM_XBOXONE || PLATFORM_PS4 || PLATFORM_LUMIN || PLATFORM_SWITCH || PLATFORM_HOLOLENS
+	return true;
+#else
+	return false;
+#endif
+}
+
+bool ITLIsManagedFileWrapperPlatform()
+{
+#if PLATFORM_USE_PLATFORM_FILE_MANAGED_STORAGE_WRAPPER
+	return true;
+#else
+	return false;
+#endif
+}
+
 FString ITLParseHttpResponseCookies(FHttpResponsePtr Response)
 {
 	FString AllCookies;
@@ -600,9 +618,9 @@ SPARKLOGS_API FString ITLGenerateRandomAlphaNumID(int Length)
 
 FString ITLGetIndexedStateFileINI(int InstanceIndex)
 {
-	if (InstanceIndex <= 1 && FPlatformProperties::RequiresCookedData())
+	if (InstanceIndex <= 1 && FPlatformProperties::RequiresCookedData() && (ITLIsMobilePlatform() || ITLIsConsolePlatform() || ITLIsManagedFileWrapperPlatform()))
 	{
-		ITL_DBG_UE_LOG(LogPluginSparkLogs, Display, TEXT("ITLGetIndexedStateFileINI|Cooked data is required and this is the primary instance, using game user settings INI for state file..."));
+		ITL_DBG_UE_LOG(LogPluginSparkLogs, Display, TEXT("ITLGetIndexedStateFileINI|Cooked data is required and this is the primary instance on mobile/console, using game user settings INI for state file..."));
 		return GGameUserSettingsIni;
 	}
 	else

--- a/Source/sparklogs/Public/sparklogs.h
+++ b/Source/sparklogs/Public/sparklogs.h
@@ -141,8 +141,8 @@ public:
 	static constexpr double MinEditorProcessingIntervalSecs = 0.5;
 	static constexpr double DefaultEditorProcessingIntervalSecs = 2.0;
 	// There could be millions of clients, so give more time for data to queue up before flushing...
-	static constexpr double MinClientProcessingIntervalSecs = 15.0;
-	static constexpr double DefaultClientProcessingIntervalSecs = 30.0;
+	static constexpr double MinClientProcessingIntervalSecs = 3.0;
+	static constexpr double DefaultClientProcessingIntervalSecs = 6.0;
 
 	static constexpr bool DefaultServerCollectAnalytics = true;
 	static constexpr bool DefaultServerCollectLogs = true;
@@ -580,7 +580,7 @@ public:
 	UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Advanced Settings In Client Launch Configuration", DisplayName = "Bytes Per Request")
 	int32 ClientBytesPerRequest = FsparklogsSettings::DefaultBytesPerRequest;
 
-	// Target seconds between attempts to read and process a chunk. For efficiency, data from game clients is only flushed every few minutes or at key points like end of session.
+	// Target seconds between attempts to read and process a chunk.
 	UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Advanced Settings In Client Launch Configuration", DisplayName = "Processing Interval in Seconds")
 	float ClientProcessingIntervalSecs = FsparklogsSettings::DefaultClientProcessingIntervalSecs;
 

--- a/Source/sparklogs/Public/sparklogs.h
+++ b/Source/sparklogs/Public/sparklogs.h
@@ -108,6 +108,8 @@ SPARKLOGS_API FString ITLGetIndexedStateFileINI(int InstanceIndex);
 class SPARKLOGS_API FsparklogsSettings
 {
 public:
+	static constexpr const TCHAR* UserIDKey = TEXT("AnalyticsUserID");
+
 	static constexpr const TCHAR* AnalyticsUserIDTypeDeviceID = TEXT("device_id");
 	static constexpr const TCHAR* AnalyticsUserIDTypeGenerated = TEXT("generated");
 	static constexpr const TCHAR* DefaultAnalyticsUserIDType = AnalyticsUserIDTypeDeviceID;
@@ -1074,6 +1076,14 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "SparkLogs")
 	static void EndSessionWithReason(const FString& Reason);
 
+	/** Gets the current user ID */
+	UFUNCTION(BlueprintCallable, Category = "SparkLogs")
+	static FString GetUserID();
+
+	/** Sets a custom user ID */
+	UFUNCTION(BlueprintCallable, Category = "SparkLogs")
+	static void SetUserID(const FString& UserID);
+
 	/** Gets the ID of the current session, or returns an empty string if none is active. */
 	UFUNCTION(BlueprintCallable, Category = "SparkLogs")
 	static FString GetSessionID();
@@ -1668,7 +1678,7 @@ public:
 	// Prepares for an analytics event to be generated. Ensures a session is started. Returns false if we should not proceed.
 	virtual bool AutoStartSessionBeforeEvent();
 	// Automatically cleanup any active session, except for server launch configurations where we only send session data if they explicitly use StartSession and EndSession.
-	virtual void AutoCleanupSession();
+	virtual void AutoCleanupSession(const FString &Reason);
 	// Checks if there is a session that was active in a previous instance of the game that wasn't ended properly. If so, mark that session as ended with the appropriate duration.
 	virtual void CheckForStaleSessionAtStartup();
 

--- a/Source/sparklogs/Public/sparklogs.h
+++ b/Source/sparklogs/Public/sparklogs.h
@@ -62,6 +62,12 @@ SPARKLOGS_API FDateTime ITLParseDateTime(const FString & TimeStr);
 /** Returns true if we're on a mobile platform. */
 SPARKLOGS_API bool ITLIsMobilePlatform();
 
+/** Returns true if we're on a console platform. */
+SPARKLOGS_API bool ITLIsConsolePlatform();
+
+/** Returns true if this platform is using a managed file wrapper. */
+SPARKLOGS_API bool ITLIsManagedFileWrapperPlatform();
+
 /** Parses all cookies in Set-Cookie headers in the given HTTP response and returns the combined value that would be used for the
   * Cookie header on a new HTTP request. It strips all optional fields from cookies and just adds the name=value for each cookie. */
 SPARKLOGS_API FString ITLParseHttpResponseCookies(FHttpResponsePtr Response);

--- a/Source/sparklogs/Public/sparklogs.h
+++ b/Source/sparklogs/Public/sparklogs.h
@@ -149,8 +149,8 @@ public:
 	static constexpr double MinEditorProcessingIntervalSecs = 0.5;
 	static constexpr double DefaultEditorProcessingIntervalSecs = 2.0;
 	// There could be millions of clients, so give more time for data to queue up before flushing...
-	static constexpr double MinClientProcessingIntervalSecs = 3.0;
-	static constexpr double DefaultClientProcessingIntervalSecs = 6.0;
+	static constexpr double MinClientProcessingIntervalSecs = 6.0;
+	static constexpr double DefaultClientProcessingIntervalSecs = 12.0;
 
 	static constexpr bool DefaultServerCollectAnalytics = true;
 	static constexpr bool DefaultServerCollectLogs = true;

--- a/sparklogs.uplugin
+++ b/sparklogs.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "1.0.8",
+	"VersionName": "1.0.9",
 	"FriendlyName": "SparkLogs",
 	"Description": "Ship game engine logs and analytics to SparkLogs, a cost effective, petabyte-scale cloud logging service that's actually a joy to use. Can also be used to ship logs and analytics to any HTTP(S) endpoint that accepts JSON.",
 	"Category": "Analytics",


### PR DESCRIPTION
This enhances the plugin so that if a game engine process crashes after sending a payload and before it receives an acknowledgement of that payload, when the game engine restarts it will send the same payload again if possible. It does this by remembering the size of the last payload as well as any common metadata used by the last game engine instance, allowing it to reconstruct an identical payload from the queue file. This will allow the SparkLogs cloud to dedup such identical payload and prevent duplicate data from being received, even across game engine crashes/restarts.

These enhancements are fully covered with automation tests.

Other minor changes:
* Reduce client batch interval to 12 seconds (send analytics data faster)
* Persist any custom analytics user ID across game engine restarts
* Use dedicated state INI file on desktop platforms (avoid rewriting larger user settings INI file now that we rewrite state more often)
* Synchronize any physical writes of the INI file to avoid racing on this
* Fix unit tests randomly failing because Unreal Engine caching old unit test state INI files