### PR TITLE
Version 1.0.11: Rename agent auth settings to Ingest Key terminology

### DIFF
--- a/Config/Basesparklogs.ini
+++ b/Config/Basesparklogs.ini
@@ -1,3 +1,3 @@
 [/Script/sparklogs.SparkLogsRuntimeSettings]
-ServerAgentID=my-agent-id
-ServerAgentAuthToken=this-is-my-auth-token
+ServerIngestKeyID=my-ingest-key-id
+ServerIngestKeyAuthToken=this-is-my-auth-token

--- a/Examples/local-elasticsearch-kibana/README.md
+++ b/Examples/local-elasticsearch-kibana/README.md
@@ -9,7 +9,7 @@ Kibana with a data view for visualizing the log data ingested into the Elasticse
 If you want to easily collaborate over logs with your entire team, consider using the
 plugin with the [SparkLogs Cloud](https://sparklogs.com/). Configuration is easy,
 just specify the cloud region for your account in the plugin settings, as well as the
-agent ID and auth token from your account. Logs will then flow to your cloud account.
+ingest key ID and access token from your account. Logs will then flow to your cloud account.
 
 ## Prerequisites
 

--- a/Source/sparklogs/Private/Tests/sparklogsTest.cpp
+++ b/Source/sparklogs/Private/Tests/sparklogsTest.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024-2025 IT Lightning, LLC. All rights reserved.
+﻿// Copyright (C) 2024-2026 IT Lightning, LLC. All rights reserved.
 // Licensed software - see LICENSE
 
 #include "Misc/AutomationTest.h"
@@ -1261,5 +1261,80 @@ bool FsparklogsPluginIntegrationTestAutoFlushRawEvent::RunTest(const FString& Pa
     TestTrue(TEXT("FlushAndWait[FINAL] should capture everything"), FlushedEverything);
 
     Streamer.Reset();
+    return true;
+}
+
+class FITLTestTempIniFile
+{
+public:
+    explicit FITLTestTempIniFile(const FString& InPath) : Path(InPath)
+    {
+        IFileManager::Get().Delete(*Path, false, true, true);
+    }
+
+    ~FITLTestTempIniFile()
+    {
+        GConfig->Remove(Path);
+        IFileManager::Get().Delete(*Path, false, true, true);
+    }
+
+    FString Path;
+};
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FsparklogsPluginUnitTestIngestKeyConfigFallback, "sparklogs.UnitTests.IngestKeyConfigFallback", EAutomationTestFlags::EditorContext | EAutomationTestFlags::CriticalPriority | EAutomationTestFlags::EngineFilter)
+bool FsparklogsPluginUnitTestIngestKeyConfigFallback::RunTest(const FString& Parameters)
+{
+    const FString Section = ITL_CONFIG_SECTION_NAME;
+    const FString TempIni = FPaths::CreateTempFilename(*FPaths::ProjectIntermediateDir(), TEXT("itl-ingestkey-test-"), TEXT(".ini"));
+    FITLTestTempIniFile TempIniGuard(TempIni);
+
+    GConfig->SetString(*Section, TEXT("ServerIngestKeyID"), TEXT("new-id"), TempIni);
+    TestEqual(TEXT("New key wins"), ITLLoadConfigStringWithLegacyFallback(Section, TEXT("ServerIngestKeyID"), TEXT("ServerAgentID"), TempIni), FString(TEXT("new-id")));
+
+    GConfig->EmptySection(*Section, TempIni);
+    GConfig->SetString(*Section, TEXT("ServerAgentID"), TEXT("legacy-id"), TempIni);
+    TestEqual(TEXT("Legacy fallback"), ITLLoadConfigStringWithLegacyFallback(Section, TEXT("ServerIngestKeyID"), TEXT("ServerAgentID"), TempIni), FString(TEXT("legacy-id")));
+
+    GConfig->SetString(*Section, TEXT("ServerIngestKeyID"), TEXT("new-id"), TempIni);
+    TestEqual(TEXT("Both set prefers new"), ITLLoadConfigStringWithLegacyFallback(Section, TEXT("ServerIngestKeyID"), TEXT("ServerAgentID"), TempIni), FString(TEXT("new-id")));
+
+    GConfig->EmptySection(*Section, TempIni);
+    GConfig->SetString(*Section, TEXT("CommandletAgentAuthToken"), TEXT("legacy-commandlet-token"), TempIni);
+    TestEqual(TEXT("Commandlet legacy token fallback"), ITLLoadConfigStringWithLegacyFallback(Section, TEXT("CommandletIngestKeyAuthToken"), TEXT("CommandletAgentAuthToken"), TempIni), FString(TEXT("legacy-commandlet-token")));
+
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FsparklogsPluginUnitTestLoadSettingsIngestKeyLegacy, "sparklogs.UnitTests.LoadSettingsIngestKeyLegacy", EAutomationTestFlags::EditorContext | EAutomationTestFlags::CriticalPriority | EAutomationTestFlags::EngineFilter)
+bool FsparklogsPluginUnitTestLoadSettingsIngestKeyLegacy::RunTest(const FString& Parameters)
+{
+    const FString Section = ITL_CONFIG_SECTION_NAME;
+    const FString Prefix = TEXT("Editor");
+    const FString LegacyIDKey = Prefix + TEXT("AgentID");
+    const FString LegacyTokenKey = Prefix + TEXT("AgentAuthToken");
+    const FString NewIDKey = Prefix + TEXT("IngestKeyID");
+    const FString NewTokenKey = Prefix + TEXT("IngestKeyAuthToken");
+
+    GConfig->SetString(*Section, *LegacyIDKey, TEXT("legacy-editor-id"), GEngineIni);
+    GConfig->SetString(*Section, *LegacyTokenKey, TEXT("legacy-editor-token"), GEngineIni);
+    GConfig->RemoveKey(*Section, *NewIDKey, GEngineIni);
+    GConfig->RemoveKey(*Section, *NewTokenKey, GEngineIni);
+
+    TSharedRef<FsparklogsSettings> Settings(new FsparklogsSettings(1));
+    Settings->LoadSettings();
+
+    TestEqual(TEXT("LoadSettings legacy ID"), Settings->IngestKeyID, FString(TEXT("legacy-editor-id")));
+    TestEqual(TEXT("LoadSettings legacy token"), Settings->IngestKeyAuthToken, FString(TEXT("legacy-editor-token")));
+
+    GConfig->SetString(*Section, *NewIDKey, TEXT("new-editor-id"), GEngineIni);
+    GConfig->SetString(*Section, *NewTokenKey, TEXT("new-editor-token"), GEngineIni);
+    Settings->LoadSettings();
+    TestEqual(TEXT("LoadSettings new ID wins"), Settings->IngestKeyID, FString(TEXT("new-editor-id")));
+    TestEqual(TEXT("LoadSettings new token wins"), Settings->IngestKeyAuthToken, FString(TEXT("new-editor-token")));
+
+    GConfig->RemoveKey(*Section, *LegacyIDKey, GEngineIni);
+    GConfig->RemoveKey(*Section, *LegacyTokenKey, GEngineIni);
+    GConfig->RemoveKey(*Section, *NewIDKey, GEngineIni);
+    GConfig->RemoveKey(*Section, *NewTokenKey, GEngineIni);
     return true;
 }

--- a/Source/sparklogs/Private/sparklogs.cpp
+++ b/Source/sparklogs/Private/sparklogs.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 IT Lightning, LLC. All rights reserved.
+// Copyright (C) 2024-2026 IT Lightning, LLC. All rights reserved.
 // Licensed software - see LICENSE
 
 #include "sparklogs.h"
@@ -1099,6 +1099,170 @@ void FsparklogsSettings::GetLastAnalyticsSessionStartInfo(FString& OutSessionID,
 	OutSessionStarted = ITLParseDateTime(TimeStr);
 }
 
+static constexpr const TCHAR* ITLIngestKeyIDSuffix = TEXT("IngestKeyID");
+static constexpr const TCHAR* ITLIngestKeyAuthTokenSuffix = TEXT("IngestKeyAuthToken");
+static constexpr const TCHAR* ITLLegacyIngestKeyIDSuffix = TEXT("AgentID");
+static constexpr const TCHAR* ITLLegacyIngestKeyAuthTokenSuffix = TEXT("AgentAuthToken");
+
+FString ITLLoadConfigStringWithLegacyFallback(const FString& Section, const FString& KeyName, const FString& LegacyKeyName, const FString& ConfigFilename)
+{
+	FString Value = GConfig->GetStr(*Section, *KeyName, *ConfigFilename);
+	Value.TrimStartAndEndInline();
+	if (Value.IsEmpty())
+	{
+		Value = GConfig->GetStr(*Section, *LegacyKeyName, *ConfigFilename);
+		Value.TrimStartAndEndInline();
+	}
+	return Value;
+}
+
+static FString ITLReadTrimmedConfigString(const FString& Section, const FString& KeyName, const FString& ConfigFilename)
+{
+	FString Value = GConfig->GetStr(*Section, *KeyName, *ConfigFilename);
+	Value.TrimStartAndEndInline();
+	return Value;
+}
+
+struct FITLIngestKeyCredentialMigration
+{
+	FString LegacyIDKey;
+	FString NewIDKey;
+	FString LegacyTokenKey;
+	FString NewTokenKey;
+	FString ExpectedID;
+	FString ExpectedToken;
+	bool bMigrateID = false;
+	bool bMigrateToken = false;
+};
+
+static void ITLMigrateLegacyAgentConfigKeysInEditor(FsparklogsSettings* Settings)
+{
+	if (!GIsEditor || !UObjectInitialized())
+	{
+		return;
+	}
+
+	const FString Section = ITL_CONFIG_SECTION_NAME;
+	const FString DefaultEngineIniPath = FPaths::ProjectConfigDir() + TEXT("DefaultEngine.ini");
+	if (!FPaths::FileExists(DefaultEngineIniPath))
+	{
+		return;
+	}
+
+	static const TCHAR* Prefixes[] = {
+		INISectionForServer,
+		INISectionForEditor,
+		INISectionForClient,
+		INISectionForCommandlet,
+	};
+
+	TArray<FITLIngestKeyCredentialMigration> Migrations;
+	bool bAnyMigration = false;
+
+	for (const TCHAR* Prefix : Prefixes)
+	{
+		const FString PrefixStr(Prefix);
+		const FString LegacyIDKey = PrefixStr + ITLLegacyIngestKeyIDSuffix;
+		const FString NewIDKey = PrefixStr + ITLIngestKeyIDSuffix;
+		const FString LegacyTokenKey = PrefixStr + ITLLegacyIngestKeyAuthTokenSuffix;
+		const FString NewTokenKey = PrefixStr + ITLIngestKeyAuthTokenSuffix;
+
+		const FString LegacyID = ITLReadTrimmedConfigString(Section, LegacyIDKey, GEngineIni);
+		const FString NewID = ITLReadTrimmedConfigString(Section, NewIDKey, GEngineIni);
+		const FString LegacyToken = ITLReadTrimmedConfigString(Section, LegacyTokenKey, GEngineIni);
+		const FString NewToken = ITLReadTrimmedConfigString(Section, NewTokenKey, GEngineIni);
+
+		FITLIngestKeyCredentialMigration Entry;
+		Entry.LegacyIDKey = LegacyIDKey;
+		Entry.NewIDKey = NewIDKey;
+		Entry.LegacyTokenKey = LegacyTokenKey;
+		Entry.NewTokenKey = NewTokenKey;
+
+		if (!LegacyID.IsEmpty() && !NewID.IsEmpty() && LegacyID != NewID)
+		{
+			UE_LOG(LogPluginSparkLogs, Warning, TEXT("SparkLogs ingest key config: %s has both legacy and new ID values that differ; keeping new value."), *NewIDKey);
+		}
+		if (!LegacyToken.IsEmpty() && !NewToken.IsEmpty() && LegacyToken != NewToken)
+		{
+			UE_LOG(LogPluginSparkLogs, Warning, TEXT("SparkLogs ingest key config: %s has both legacy and new auth token values that differ; keeping new value."), *NewTokenKey);
+		}
+
+		if (!LegacyID.IsEmpty() && NewID.IsEmpty())
+		{
+			Entry.bMigrateID = true;
+			Entry.ExpectedID = LegacyID;
+			// Write only the migrated keys; do not use UObject::SaveConfig (would rewrite unrelated settings from CDO defaults).
+			GConfig->SetString(*Section, *NewIDKey, *LegacyID, DefaultEngineIniPath);
+			bAnyMigration = true;
+		}
+		if (!LegacyToken.IsEmpty() && NewToken.IsEmpty())
+		{
+			Entry.bMigrateToken = true;
+			Entry.ExpectedToken = LegacyToken;
+			GConfig->SetString(*Section, *NewTokenKey, *LegacyToken, DefaultEngineIniPath);
+			bAnyMigration = true;
+		}
+
+		if (Entry.bMigrateID || Entry.bMigrateToken)
+		{
+			Migrations.Add(Entry);
+		}
+	}
+
+	if (!bAnyMigration)
+	{
+		return;
+	}
+
+	GConfig->Flush(true, DefaultEngineIniPath);
+
+	bool bAllVerified = true;
+	for (const FITLIngestKeyCredentialMigration& Entry : Migrations)
+	{
+		if (Entry.bMigrateID)
+		{
+			const FString Verified = ITLReadTrimmedConfigString(Section, Entry.NewIDKey, DefaultEngineIniPath);
+			if (Verified != Entry.ExpectedID)
+			{
+				UE_LOG(LogPluginSparkLogs, Warning, TEXT("SparkLogs ingest key config: failed to verify migrated value for %s; leaving legacy keys unchanged."), *Entry.NewIDKey);
+				bAllVerified = false;
+			}
+		}
+		if (Entry.bMigrateToken)
+		{
+			const FString Verified = ITLReadTrimmedConfigString(Section, Entry.NewTokenKey, DefaultEngineIniPath);
+			if (Verified != Entry.ExpectedToken)
+			{
+				UE_LOG(LogPluginSparkLogs, Warning, TEXT("SparkLogs ingest key config: failed to verify migrated value for %s; leaving legacy keys unchanged."), *Entry.NewTokenKey);
+				bAllVerified = false;
+			}
+		}
+	}
+
+	if (bAllVerified)
+	{
+		for (const FITLIngestKeyCredentialMigration& Entry : Migrations)
+		{
+			if (Entry.bMigrateID)
+			{
+				GConfig->RemoveKey(*Section, *Entry.LegacyIDKey, DefaultEngineIniPath);
+			}
+			if (Entry.bMigrateToken)
+			{
+				GConfig->RemoveKey(*Section, *Entry.LegacyTokenKey, DefaultEngineIniPath);
+			}
+		}
+		GConfig->Flush(true, DefaultEngineIniPath);
+	}
+
+	// NOTE: even if verification failed, new keys may be on disk so still refresh UObject from INI
+	GetMutableDefault<USparkLogsRuntimeSettings>()->ReloadConfig(CPF_Config, *DefaultEngineIniPath);
+	if (Settings != nullptr)
+	{
+		Settings->LoadSettings();
+	}
+}
+
 void FsparklogsSettings::LoadSettings()
 {
 	FString Section = ITL_CONFIG_SECTION_NAME;
@@ -1159,8 +1323,8 @@ void FsparklogsSettings::LoadSettings()
 		RequestTimeoutSecs = DefaultRequestTimeoutSecs;
 	}
 
-	AgentID = GConfig->GetStr(*Section, *(SettingPrefix + TEXT("AgentID")), GEngineIni);
-	AgentAuthToken = GConfig->GetStr(*Section, *(SettingPrefix + TEXT("AgentAuthToken")), GEngineIni);
+	IngestKeyID = ITLLoadConfigStringWithLegacyFallback(Section, SettingPrefix + ITLIngestKeyIDSuffix, SettingPrefix + ITLLegacyIngestKeyIDSuffix, GEngineIni);
+	IngestKeyAuthToken = ITLLoadConfigStringWithLegacyFallback(Section, SettingPrefix + ITLIngestKeyAuthTokenSuffix, SettingPrefix + ITLLegacyIngestKeyAuthTokenSuffix, GEngineIni);
 	HttpAuthorizationHeaderValue = GConfig->GetStr(*Section, *(SettingPrefix + TEXT("HTTPAuthorizationHeaderValue")), GEngineIni);
 	
 	FString StringActivationPercentage;
@@ -1265,8 +1429,8 @@ void FsparklogsSettings::LoadSettings()
 
 void FsparklogsSettings::EnforceConstraints()
 {
-	AgentID.TrimStartAndEndInline();
-	AgentAuthToken.TrimStartAndEndInline();
+	IngestKeyID.TrimStartAndEndInline();
+	IngestKeyAuthToken.TrimStartAndEndInline();
 
 	if (RequestTimeoutSecs < MinRequestTimeoutSecs)
 	{
@@ -5262,16 +5426,16 @@ bool FsparklogsModule::StartShippingEngine(const FSparkLogsEngineOptions& option
 		Settings->CollectAnalytics = EffectiveCollectAnalytics;
 	}
 
-	FString EffectiveAgentID = Settings->AgentID;
-	FString EffectiveAgentAuthToken = Settings->AgentAuthToken;
+	FString EffectiveIngestKeyID = Settings->IngestKeyID;
+	FString EffectiveIngestKeyAuthToken = Settings->IngestKeyAuthToken;
 	FString EffectiveHttpAuthorizationHeaderValue = Settings->HttpAuthorizationHeaderValue;
-	if (options.OverrideAgentID.Len() > 0)
+	if (options.OverrideIngestKeyID.Len() > 0)
 	{
-		EffectiveAgentID = options.OverrideAgentID;
+		EffectiveIngestKeyID = options.OverrideIngestKeyID;
 	}
-	if (options.OverrideAgentAuthToken.Len() > 0)
+	if (options.OverrideIngestKeyAuthToken.Len() > 0)
 	{
-		EffectiveAgentAuthToken = options.OverrideAgentAuthToken;
+		EffectiveIngestKeyAuthToken = options.OverrideIngestKeyAuthToken;
 	}
 	if (options.OverrideHttpAuthorizationHeaderValue.Len() > 0)
 	{
@@ -5285,7 +5449,7 @@ bool FsparklogsModule::StartShippingEngine(const FSparkLogsEngineOptions& option
 		UE_LOG(LogPluginSparkLogs, Log, TEXT("Not yet configured for this launch configuration. In plugin settings for %s launch configuration, configure CloudRegion to 'us' or 'eu' for your SparkLogs cloud region (or if you are sending data to your own HTTP service, configure HttpEndpointURI to the appropriate endpoint, such as http://localhost:9880/ or https://ingestlogs.myservice.com/ingest/v1)"), *GetITLINISettingPrefix());
 		return false;
 	}
-	if (UsingSparkLogsCloud && (EffectiveAgentID.IsEmpty() || EffectiveAgentAuthToken.IsEmpty()))
+	if (UsingSparkLogsCloud && (EffectiveIngestKeyID.IsEmpty() || EffectiveIngestKeyAuthToken.IsEmpty()))
 	{
 		UE_LOG(LogPluginSparkLogs, Log, TEXT("Not yet configured for this launch configuration. In plugin settings for %s launch configuration, configure authentication credentials to enable. Consider using credentials for Editor vs Client vs Server."), *GetITLINISettingPrefix());
 		return false;
@@ -5294,7 +5458,7 @@ bool FsparklogsModule::StartShippingEngine(const FSparkLogsEngineOptions& option
 	// If we're sending data to the SparkLogs cloud then use lz4 compression by default, otherwise use none as lz4 support is nonstandard.
 	if (Settings->CompressionMode == ITLCompressionMode::Default)
 	{
-		if (UsingSparkLogsCloud || (!EffectiveAgentID.IsEmpty() && !EffectiveAgentAuthToken.IsEmpty()))
+		if (UsingSparkLogsCloud || (!EffectiveIngestKeyID.IsEmpty() && !EffectiveIngestKeyAuthToken.IsEmpty()))
 		{
 			UE_LOG(LogPluginSparkLogs, Log, TEXT("Sending data to SparkLogs cloud, so using lz4 as default compression mode."));
 			Settings->CompressionMode = ITLCompressionMode::LZ4;
@@ -5327,7 +5491,7 @@ bool FsparklogsModule::StartShippingEngine(const FSparkLogsEngineOptions& option
 		}
 	}
 
-	UE_LOG(LogPluginSparkLogs, Log, TEXT("Starting up: LaunchConfiguration=%s, HttpEndpointURI=%s, AgentID=%s, ActivationPercentage=%lf, DiceRoll=%f, Activated=%s, CollectLogs=%s, CollectAnalytics=%s"), GetITLLaunchConfiguration(true), *EffectiveHttpEndpointURI, *EffectiveAgentID, Settings->ActivationPercentage, DiceRoll, EngineActive ? TEXT("yes") : TEXT("no"), EffectiveCollectLogs ? TEXT("yes") : TEXT("no"), EffectiveCollectAnalytics ? TEXT("yes") : TEXT("no"));
+	UE_LOG(LogPluginSparkLogs, Log, TEXT("Starting up: LaunchConfiguration=%s, HttpEndpointURI=%s, IngestKeyID=%s, ActivationPercentage=%lf, DiceRoll=%f, Activated=%s, CollectLogs=%s, CollectAnalytics=%s"), GetITLLaunchConfiguration(true), *EffectiveHttpEndpointURI, *EffectiveIngestKeyID, Settings->ActivationPercentage, DiceRoll, EngineActive ? TEXT("yes") : TEXT("no"), EffectiveCollectLogs ? TEXT("yes") : TEXT("no"), EffectiveCollectAnalytics ? TEXT("yes") : TEXT("no"));
 	if (!EffectiveCollectLogs && !EffectiveCollectAnalytics)
 	{
 		UE_LOG(LogPluginSparkLogs, Log, TEXT("Log collection and analytics collection are both disabled. No reason to start engine."));
@@ -5352,7 +5516,7 @@ bool FsparklogsModule::StartShippingEngine(const FSparkLogsEngineOptions& option
 		FString AuthorizationHeader;
 		if (EffectiveHttpAuthorizationHeaderValue.IsEmpty())
 		{
-			AuthorizationHeader = FString::Format(TEXT("Bearer {0}:{1}"), { *EffectiveAgentID, *EffectiveAgentAuthToken });
+			AuthorizationHeader = FString::Format(TEXT("Bearer {0}:{1}"), { *EffectiveIngestKeyID, *EffectiveIngestKeyAuthToken });
 		}
 		else
 		{
@@ -5485,6 +5649,7 @@ void FsparklogsModule::OnPostEngineInit()
 {
 	if (UObjectInitialized())
 	{
+		ITLMigrateLegacyAgentConfigKeysInEditor(&Settings.Get());
 		// Allow the user to edit settings in the project settings editor
 		RegisterSettings();
 	}

--- a/Source/sparklogs/Public/sparklogs.h
+++ b/Source/sparklogs/Public/sparklogs.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 IT Lightning, LLC. All rights reserved.
+// Copyright (C) 2024-2026 IT Lightning, LLC. All rights reserved.
 // Licensed software - see LICENSE
 
 #pragma once
@@ -78,6 +78,9 @@ SPARKLOGS_API FString ITLCalcUniqueFieldName(const TSharedPtr<FJsonObject> Objec
 
 /** Returns a sanitized version of the given string that is safe to use as an INI key name */
 SPARKLOGS_API FString ITLSanitizeINIKeyName(const FString & In);
+
+/** Loads a config string preferring KeyName; falls back to LegacyKeyName when the primary value is empty. */
+SPARKLOGS_API FString ITLLoadConfigStringWithLegacyFallback(const FString& Section, const FString& KeyName, const FString& LegacyKeyName, const FString& ConfigFilename);
 
 /** Tries really hard to delete the given file, or if that fails to rename it. Returns true on success or false otherwise. */
 SPARKLOGS_API bool ITLPurgeFile(const FString & Path);
@@ -191,11 +194,11 @@ public:
 	FString HttpEndpointURI;
 	/** Request timeout in seconds */
 	double RequestTimeoutSecs;
-	/** ID of the agent when pushing logs to the cloud */
-	FString AgentID;
-	/** Auth token associated with the agent when pushing logs to the cloud */
-	FString AgentAuthToken;
-	/** Overrides the HTTP Authorization header value directly (if specified, the AgentID and AgentAuthToken values will be ignored). Useful if you specify your own HTTP endpoint. */
+	/** Ingest Key ID when pushing logs to the cloud */
+	FString IngestKeyID;
+	/** Ingest Key auth token when pushing logs to the cloud */
+	FString IngestKeyAuthToken;
+	/** Overrides the HTTP Authorization header value directly (if specified, the IngestKeyID and IngestKeyAuthToken values will be ignored). Useful if you specify your own HTTP endpoint. */
 	FString HttpAuthorizationHeaderValue;
 	/** What percent of the time to activate this plugin (whether started automatically or manually). 0.0 to 100.0. Defaults to 100%. Useful for incrementally rolling out the plugin. */
 	double ActivationPercentage;
@@ -384,19 +387,19 @@ public:
 	UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Settings In Server Launch Configuration", DisplayName = "SparkLogs Cloud Region", meta = (GetOptions = "GetSparkLogsCloudRegionOptions"))
 	FString ServerCloudRegion;
 
-	// For authentication: ID of the cloud agent that will receive the ingested log data.
-	UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Settings In Server Launch Configuration", DisplayName = "SparkLogs Agent ID")
-	FString ServerAgentID;
+	// For authentication: Ingest Key ID that will receive the ingested log data.
+	UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Settings In Server Launch Configuration", DisplayName = "SparkLogs Ingest Key ID")
+	FString ServerIngestKeyID;
 
-	// For authentication: Auth token associated with the cloud agent receiving the log data.
-	UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Settings In Server Launch Configuration", DisplayName = "SparkLogs Agent Auth Token")
-	FString ServerAgentAuthToken;
+	// For authentication: Ingest Key auth token associated with the ingest key receiving the log data.
+	UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Settings In Server Launch Configuration", DisplayName = "SparkLogs Ingest Key Auth Token")
+	FString ServerIngestKeyAuthToken;
 
 	// Normally leave blank and set CloudRegion. Overrides the URI of the endpoint to push log payloads to, e.g., http://localhost:9880/ or https://ingestlogs.myservice.com/ingest/v1
 	UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Settings In Server Launch Configuration", DisplayName = "Custom HTTP Endpoint URI")
 	FString ServerHTTPEndpointURI;
 
-	// Normally leave blank and set AgentID and AgentAuthToken. Overrides the HTTP Authorization header value directly. Useful if you specify your own HTTP endpoint. For example: Bearer mybearertokenvalue
+	// Normally leave blank and set IngestKeyID and IngestKeyAuthToken. Overrides the HTTP Authorization header value directly. Useful if you specify your own HTTP endpoint. For example: Bearer mybearertokenvalue
 	UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Settings In Server Launch Configuration", DisplayName = "Custom HTTP Authorization Header Value")
 	FString ServerHTTPAuthorizationHeaderValue;
 
@@ -430,19 +433,19 @@ public:
 	UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Settings In Editor Launch Configuration", Meta = (ConfigRestartRequired = true, GetOptions = "GetSparkLogsCloudRegionOptions"), DisplayName = "SparkLogs Cloud Region")
 	FString EditorCloudRegion;
 
-	// For authentication: ID of the cloud agent that will receive the ingested log data. [EDITOR RESTART REQUIRED]
-	UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Settings In Editor Launch Configuration", Meta = (ConfigRestartRequired = true), DisplayName="SparkLogs Agent ID")
-	FString EditorAgentID;
+	// For authentication: Ingest Key ID that will receive the ingested log data. [EDITOR RESTART REQUIRED]
+	UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Settings In Editor Launch Configuration", Meta = (ConfigRestartRequired = true), DisplayName="SparkLogs Ingest Key ID")
+	FString EditorIngestKeyID;
 
-	// For authentication: Auth token associated with the cloud agent receiving the log data. [EDITOR RESTART REQUIRED]
-	UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Settings In Editor Launch Configuration", Meta = (ConfigRestartRequired = true), DisplayName="SparkLogs Agent Auth Token")
-	FString EditorAgentAuthToken;
+	// For authentication: Ingest Key auth token associated with the ingest key receiving the log data. [EDITOR RESTART REQUIRED]
+	UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Settings In Editor Launch Configuration", Meta = (ConfigRestartRequired = true), DisplayName="SparkLogs Ingest Key Auth Token")
+	FString EditorIngestKeyAuthToken;
 
 	// Normally leave blank and set CloudRegion. Overrides the URI of the endpoint to push log payloads to, e.g., http://localhost:9880/ or https://ingestlogs.myservice.com/ingest/v1 [EDITOR RESTART REQUIRED]
 	UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Settings In Editor Launch Configuration", Meta = (ConfigRestartRequired = true), DisplayName = "Custom HTTP Endpoint URI")
 	FString EditorHTTPEndpointURI;
 
-	// Normally leave blank and set AgentID and AgentAuthToken. Overrides the HTTP Authorization header value directly. Useful if you specify your own HTTP endpoint. For example: Bearer mybearertokenvalue [EDITOR RESTART REQUIRED]
+	// Normally leave blank and set IngestKeyID and IngestKeyAuthToken. Overrides the HTTP Authorization header value directly. Useful if you specify your own HTTP endpoint. For example: Bearer mybearertokenvalue [EDITOR RESTART REQUIRED]
 	UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Settings In Editor Launch Configuration", Meta = (ConfigRestartRequired = true), DisplayName = "Custom HTTP Authorization Header Value")
 	FString EditorHTTPAuthorizationHeaderValue;
 
@@ -476,19 +479,19 @@ public:
 	UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Settings In Client Launch Configuration", DisplayName = "SparkLogs Cloud Region", meta = (GetOptions = "GetSparkLogsCloudRegionOptions"))
 	FString ClientCloudRegion;
 
-	// For authentication: ID of the cloud agent that will receive the ingested log data.
-	UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Settings In Client Launch Configuration", DisplayName = "SparkLogs Agent ID")
-	FString ClientAgentID;
+	// For authentication: Ingest Key ID that will receive the ingested log data.
+	UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Settings In Client Launch Configuration", DisplayName = "SparkLogs Ingest Key ID")
+	FString ClientIngestKeyID;
 
-	// For authentication: Auth token associated with the cloud agent receiving the log data.
-	UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Settings In Client Launch Configuration", DisplayName = "SparkLogs Agent Auth Token")
-	FString ClientAgentAuthToken;
+	// For authentication: Ingest Key auth token associated with the ingest key receiving the log data.
+	UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Settings In Client Launch Configuration", DisplayName = "SparkLogs Ingest Key Auth Token")
+	FString ClientIngestKeyAuthToken;
 
 	// Normally leave blank and set CloudRegion. Overrides the URI of the endpoint to push log payloads to, e.g., http://localhost:9880/ or https://ingestlogs.myservice.com/ingest/v1
 	UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Settings In Client Launch Configuration", DisplayName = "Custom HTTP Endpoint URI")
 	FString ClientHTTPEndpointURI;
 
-	// Normally leave blank and set AgentID and AgentAuthToken. Overrides the HTTP Authorization header value directly. Useful if you specify your own HTTP endpoint. For example: Bearer mybearertokenvalue
+	// Normally leave blank and set IngestKeyID and IngestKeyAuthToken. Overrides the HTTP Authorization header value directly. Useful if you specify your own HTTP endpoint. For example: Bearer mybearertokenvalue
 	UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Settings In Client Launch Configuration", DisplayName = "Custom HTTP Authorization Header Value")
 	FString ClientHTTPAuthorizationHeaderValue;
 
@@ -1804,11 +1807,11 @@ public:
 	/** Override the target currency for automatic currency conversion (one of AUD, CAD, CHF, CNY, EUR, GBP, INR, JPY, and USD) */
 	FString OverrideAnalyticsTargetCurrency;
 	
-	/** If not empty, will override the config setting for the agent ID used to authenticate with the SparkLogs cloud. */
-	FString OverrideAgentID;
+	/** If not empty, will override the config setting for the Ingest Key ID used to authenticate with the SparkLogs cloud. */
+	FString OverrideIngestKeyID;
 	
-	/** If not empty, will override the config setting for the agent auth token used to authenticate with the SparkLogs cloud. */
-	FString OverrideAgentAuthToken;
+	/** If not empty, will override the config setting for the Ingest Key auth token used to authenticate with the SparkLogs cloud. */
+	FString OverrideIngestKeyAuthToken;
 	
 	/** If not empty, will override the config setting for the HTTP token authorization header. For example to specify custom token auth use something like "Bearer my_token_value" */
 	FString OverrideHttpAuthorizationHeaderValue;

--- a/sparklogs.uplugin
+++ b/sparklogs.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "1.0.10",
+	"VersionName": "1.0.11",
 	"FriendlyName": "SparkLogs",
 	"Description": "Ship game engine logs and analytics to SparkLogs, a cost effective, petabyte-scale cloud logging service that's actually a joy to use. Can also be used to ship logs and analytics to any HTTP(S) endpoint that accepts JSON.",
 	"Category": "Analytics",


### PR DESCRIPTION
Legacy *AgentID/*AgentAuthToken INI keys still work at runtime via read fallback. Editor-only migration copies legacy keys with GConfig, verifies on disk, then removes legacy keys.

Breaking: FSparkLogsEngineOptions override variables are renamed.
